### PR TITLE
Add --disable-doc flag and reduce layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
-FROM python:3.8
+FROM python:3.8-slim
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
-RUN apt-get install -y libtool autoconf gettext cpp shtool \
-    autogen libmagick++-6.q16-dev make autopoint
+RUN apt-get update \
+    && DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata \
+    && apt-get install -y libtool \
+    autoconf \
+    gettext \
+    cpp \
+    shtool \
+    autogen \
+    libmagick++-6.q16-dev \
+    make \
+    autopoint
 
 COPY . /src/zbar
 WORKDIR /src/zbar
-RUN autoreconf -vfi
-RUN ./configure --disable-dependency-tracking --disable-video --without-gtk --without-java --without-qt --without-python
-RUN make
+RUN autoreconf -vfi \
+    && ./configure --disable-doc --disable-dependency-tracking --disable-video --without-gtk --without-java --without-qt --without-python \
+    && make


### PR DESCRIPTION
- `make install` was failing, fixed by adding the `--disable-doc` flag

- reduced number of layers